### PR TITLE
use PAT for homebrew-tap update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'
           # distribution:
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,3 +41,4 @@ brews:
     tap:
       owner: thaim
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
Failed to update homebrew-tap repository with GITHUB_TOKEN.
Use PAT for homebrew-tap update.

> contents: write if you wish to
> - publish to [Homebrew](https://goreleaser.com/customization/homebrew/), or [Scoop](https://goreleaser.com/customization/scoop/) (assuming it's part of the same repository)

https://goreleaser.com/ci/actions/#token-permissions

Use GITHUB_TOKEN for [upload archives as GitHub Releases](https://goreleaser.com/customization/release/).