### PR TITLE
ec2id return id instead of print id to stdout

### DIFF
--- a/ec2id.go
+++ b/ec2id.go
@@ -29,7 +29,7 @@ func NewAwsClient() (EC2DescribeInstancesAPI, error){
 	return ec2.NewFromConfig(cfg), nil
 }
 
-func Ec2id(name string, client EC2DescribeInstancesAPI) error {
+func Ec2id(name string, client EC2DescribeInstancesAPI) (string, error) {
 	var params *ec2.DescribeInstancesInput = nil
 	if len(name) != 0 {
 		params = &ec2.DescribeInstancesInput{
@@ -45,11 +45,11 @@ func Ec2id(name string, client EC2DescribeInstancesAPI) error {
 	result, err := GetInstances(context.TODO(), client, params)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Got an error retrieving information about your Amazon EC2 instance")
-		return err
+		return "", err
 	}
 
 	if len(result.Reservations) == 0 {
-		return nil
+		return "", nil
 	}
 
 	// TODO jmespath.Searchで書き換えるとシンプルになる？
@@ -67,7 +67,5 @@ func Ec2id(name string, client EC2DescribeInstancesAPI) error {
 		}
 	}
 
-	fmt.Println(*filteredInstance.InstanceId)
-
-	return nil
+	return *filteredInstance.InstanceId, nil
 }

--- a/ec2id_test.go
+++ b/ec2id_test.go
@@ -42,7 +42,7 @@ func TestEc2id(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			err := Ec2id("test", tt.client)
+			id, err := Ec2id("test", tt.client)
 			if tt.wantErr {
 				if (!strings.Contains(err.Error(), tt.expectErr)) {
 					t.Errorf("expect NoSuchKey error, got %T", err)
@@ -51,6 +51,9 @@ func TestEc2id(t *testing.T) {
 			}
 			if err != nil {
 				t.Errorf("expect no error, got error: %v", err)
+			}
+			if expected := ""; id != expected {
+				t.Errorf("expect no output, got id: %s", id)
 			}
 		})
 	}

--- a/ec2id_test.go
+++ b/ec2id_test.go
@@ -19,7 +19,7 @@ func TestEc2id(t *testing.T) {
 			Filters: []types.Filter{
 				{
 					Name: aws.String("tag:Name"),
-					Values: []string{"test"},
+					Values: []string{"noexist"},
 				},
 			},
 		}).
@@ -29,6 +29,7 @@ func TestEc2id(t *testing.T) {
 	cases := []struct {
 		name string
 		client EC2DescribeInstancesAPI
+		instanceName string
 		expect string
 		wantErr bool
 		expectErr string
@@ -36,6 +37,7 @@ func TestEc2id(t *testing.T) {
 		{
 			name: "return no instance-id",
 			client: mockClient,
+			instanceName: "noexist",
 			expect: "",
 			wantErr: false,
 			expectErr: "",
@@ -44,7 +46,7 @@ func TestEc2id(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			id, err := Ec2id("test", tt.client)
+			id, err := Ec2id(tt.instanceName, tt.client)
 			if tt.wantErr {
 				if (!strings.Contains(err.Error(), tt.expectErr)) {
 					t.Errorf("expect NoSuchKey error, got %T", err)

--- a/ec2id_test.go
+++ b/ec2id_test.go
@@ -29,12 +29,14 @@ func TestEc2id(t *testing.T) {
 	cases := []struct {
 		name string
 		client EC2DescribeInstancesAPI
+		expect string
 		wantErr bool
 		expectErr string
 	}{
 		{
-			name: "",
+			name: "return no instance-id",
 			client: mockClient,
+			expect: "",
 			wantErr: false,
 			expectErr: "",
 		},
@@ -52,7 +54,7 @@ func TestEc2id(t *testing.T) {
 			if err != nil {
 				t.Errorf("expect no error, got error: %v", err)
 			}
-			if expected := ""; id != expected {
+			if expected := tt.expect; id != expected {
 				t.Errorf("expect no output, got id: %s", id)
 			}
 		})

--- a/main.go
+++ b/main.go
@@ -40,7 +40,11 @@ func main() {
 				fmt.Fprintf(os.Stderr, "initialized failed:%v\n", err)
 				os.Exit(1)
 			}
-			return Ec2id(name, client)
+			id, err := Ec2id(name, client)
+			if err == nil {
+				fmt.Println(id)
+			}
+			return err
 		},
 		HideHelpCommand: true,
 		Version: getVersion(),


### PR DESCRIPTION
Change ec2id function to return the ec2-id.
Main function print the ec2-id to stdout (this would be changed in future version).

Fix test to check if ec2id function return the expected value.
