### PR TITLE
filter instance without state running

### DIFF
--- a/ec2id.go
+++ b/ec2id.go
@@ -36,7 +36,11 @@ func Ec2id(name string, client EC2DescribeInstancesAPI) (string, error) {
 				Name:   aws.String("tag:Name"),
 				Values: []string{name},
 			},
-		}
+			{
+				Name: aws.String("instance-state-name"),
+				Values: []string{"running"},
+			},
+		},
 	}
 
 	result, err := GetInstances(context.TODO(), client, params)
@@ -53,9 +57,6 @@ func Ec2id(name string, client EC2DescribeInstancesAPI) (string, error) {
 	var filteredInstance = result.Reservations[0].Instances[0]
 	for _, v := range result.Reservations {
 		for _, instance := range v.Instances {
-			if string(filteredInstance.State.Name) == "running" && string(instance.State.Name) != "running" {
-				continue
-			}
 			if filteredInstance.LaunchTime.After(*instance.LaunchTime) {
 				continue
 			}

--- a/ec2id.go
+++ b/ec2id.go
@@ -30,14 +30,11 @@ func NewAwsClient() (EC2DescribeInstancesAPI, error){
 }
 
 func Ec2id(name string, client EC2DescribeInstancesAPI) (string, error) {
-	var params *ec2.DescribeInstancesInput = nil
-	if len(name) != 0 {
-		params = &ec2.DescribeInstancesInput{
-			Filters: []types.Filter{
-				{
-					Name:   aws.String("tag:Name"),
-					Values: []string{name},
-				},
+	var params = &ec2.DescribeInstancesInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("tag:Name"),
+				Values: []string{name},
 			},
 		}
 	}

--- a/ec2id_test.go
+++ b/ec2id_test.go
@@ -21,6 +21,10 @@ func TestEc2id(t *testing.T) {
 					Name: aws.String("tag:Name"),
 					Values: []string{"noexist"},
 				},
+				{
+					Name: aws.String("instance-state-name"),
+					Values: []string{"running"},
+				},
 			},
 		}).
 		Return(&ec2.DescribeInstancesOutput{}, nil).

--- a/ec2id_test.go
+++ b/ec2id_test.go
@@ -74,6 +74,33 @@ func TestEc2id(t *testing.T) {
 		}, nil).
 		AnyTimes()
 
+	mockClient.EXPECT().
+		DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
+			Filters: []types.Filter{
+				{
+					Name: aws.String("tag:Name"),
+					Values: []string{"test"},
+				},
+				{
+					Name: aws.String("instance-state-name"),
+					Values: []string{"running"},
+				},
+			},
+		}).
+		Return(&ec2.DescribeInstancesOutput{
+			Reservations: []types.Reservation {
+				{
+					Instances: []types.Instance {
+						{
+							InstanceId: aws.String("i-00000000000abcdef"),
+							LaunchTime: aws.Time(time.Date(2023, 1, 4, 12, 0, 0, 0, time.UTC)),
+						},
+					},
+				},
+			},
+		}, nil).
+		AnyTimes()
+
 	cases := []struct {
 		name string
 		client EC2DescribeInstancesAPI
@@ -95,6 +122,14 @@ func TestEc2id(t *testing.T) {
 			client: mockClient,
 			instanceName: "",
 			expect: "i-0123456789abcdef2",
+			wantErr: false,
+			expectErr: "",
+		},
+		{
+			name: "return instance-id",
+			client: mockClient,
+			instanceName: "test",
+			expect: "i-00000000000abcdef",
 			wantErr: false,
 			expectErr: "",
 		},


### PR DESCRIPTION
Ec2id returned instance id including stopped instance.
Return only running instance id.

Add more tests.
