### PR TITLE
Return all instances id if no argument specified 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ i-0691a69ff0914bae1
 ```
 
 You can specify the instnace's Name tag
-```
+```bash
 # retrieve the instance id with tag:Name = "sample"
 $ ec2id sample
 i-0acd9f178c934caea

--- a/ec2id.go
+++ b/ec2id.go
@@ -30,20 +30,7 @@ func NewAwsClient() (EC2DescribeInstancesAPI, error){
 }
 
 func Ec2id(name string, client EC2DescribeInstancesAPI) (string, error) {
-	var params = &ec2.DescribeInstancesInput{
-		Filters: []types.Filter{
-			{
-				Name:   aws.String("tag:Name"),
-				Values: []string{name},
-			},
-			{
-				Name: aws.String("instance-state-name"),
-				Values: []string{"running"},
-			},
-		},
-	}
-
-	result, err := GetInstances(context.TODO(), client, params)
+	result, err := GetInstances(context.TODO(), client, buildDescribeInstancesInput(name))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Got an error retrieving information about your Amazon EC2 instance")
 		return "", err
@@ -66,4 +53,20 @@ func Ec2id(name string, client EC2DescribeInstancesAPI) (string, error) {
 	}
 
 	return *filteredInstance.InstanceId, nil
+}
+
+func buildDescribeInstancesInput(name string) *ec2.DescribeInstancesInput {
+       var params = &ec2.DescribeInstancesInput{
+               Filters: []types.Filter{
+                       {
+                               Name:   aws.String("tag:Name"),
+                               Values: []string{name},
+                       },
+                       {
+                               Name: aws.String("instance-state-name"),
+                               Values: []string{"running"},
+                       },
+               },
+       }
+       return params
 }

--- a/ec2id.go
+++ b/ec2id.go
@@ -20,7 +20,7 @@ func GetInstances(c context.Context, api EC2DescribeInstancesAPI, input *ec2.Des
 	return api.DescribeInstances(c, input)
 }
 
-func NewAwsClient() (EC2DescribeInstancesAPI, error){
+func NewAwsClient() (EC2DescribeInstancesAPI, error) {
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "configuration error")
@@ -56,16 +56,16 @@ func Ec2id(name string, client EC2DescribeInstancesAPI) (string, error) {
 }
 
 func buildDescribeInstancesInput(name string) *ec2.DescribeInstancesInput {
-	var filter = []types.Filter {
-			{
-				Name: aws.String("instance-state-name"),
-				Values: []string{"running"},
-			},
+	var filter = []types.Filter{
+		{
+			Name:   aws.String("instance-state-name"),
+			Values: []string{"running"},
+		},
 	}
-	if (len(name) != 0) {
+	if len(name) != 0 {
 		filter = append(filter, types.Filter{
-				Name: aws.String("tag:Name"),
-				Values: []string{name},
+			Name:   aws.String("tag:Name"),
+			Values: []string{name},
 		})
 	}
 

--- a/ec2id.go
+++ b/ec2id.go
@@ -56,17 +56,20 @@ func Ec2id(name string, client EC2DescribeInstancesAPI) (string, error) {
 }
 
 func buildDescribeInstancesInput(name string) *ec2.DescribeInstancesInput {
-       var params = &ec2.DescribeInstancesInput{
-               Filters: []types.Filter{
-                       {
-                               Name:   aws.String("tag:Name"),
-                               Values: []string{name},
-                       },
-                       {
-                               Name: aws.String("instance-state-name"),
-                               Values: []string{"running"},
-                       },
-               },
-       }
-       return params
+	var filter = []types.Filter {
+			{
+				Name: aws.String("instance-state-name"),
+				Values: []string{"running"},
+			},
+	}
+	if (len(name) != 0) {
+		filter = append(filter, types.Filter{
+				Name: aws.String("tag:Name"),
+				Values: []string{name},
+		})
+	}
+
+	return &ec2.DescribeInstancesInput{
+		Filters: filter,
+	}
 }

--- a/ec2id_test.go
+++ b/ec2id_test.go
@@ -19,12 +19,12 @@ func TestEc2id(t *testing.T) {
 		DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
 			Filters: []types.Filter{
 				{
-					Name: aws.String("tag:Name"),
-					Values: []string{"noexist"},
-				},
-				{
 					Name: aws.String("instance-state-name"),
 					Values: []string{"running"},
+				},
+				{
+					Name: aws.String("tag:Name"),
+					Values: []string{"noexist"},
 				},
 			},
 		}).
@@ -34,10 +34,6 @@ func TestEc2id(t *testing.T) {
 	mockClient.EXPECT().
 		DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
 			Filters: []types.Filter{
-				{
-					Name: aws.String("tag:Name"),
-					Values: []string{""},
-				},
 				{
 					Name: aws.String("instance-state-name"),
 					Values: []string{"running"},
@@ -78,12 +74,12 @@ func TestEc2id(t *testing.T) {
 		DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
 			Filters: []types.Filter{
 				{
-					Name: aws.String("tag:Name"),
-					Values: []string{"test"},
-				},
-				{
 					Name: aws.String("instance-state-name"),
 					Values: []string{"running"},
+				},
+				{
+					Name: aws.String("tag:Name"),
+					Values: []string{"test"},
 				},
 			},
 		}).

--- a/ec2id_test.go
+++ b/ec2id_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/golang/mock/gomock"
 )
 
 func TestEc2id(t *testing.T) {
@@ -19,11 +19,11 @@ func TestEc2id(t *testing.T) {
 		DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
 			Filters: []types.Filter{
 				{
-					Name: aws.String("instance-state-name"),
+					Name:   aws.String("instance-state-name"),
 					Values: []string{"running"},
 				},
 				{
-					Name: aws.String("tag:Name"),
+					Name:   aws.String("tag:Name"),
 					Values: []string{"noexist"},
 				},
 			},
@@ -35,15 +35,15 @@ func TestEc2id(t *testing.T) {
 		DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
 			Filters: []types.Filter{
 				{
-					Name: aws.String("instance-state-name"),
+					Name:   aws.String("instance-state-name"),
 					Values: []string{"running"},
 				},
 			},
 		}).
 		Return(&ec2.DescribeInstancesOutput{
-			Reservations: []types.Reservation {
+			Reservations: []types.Reservation{
 				{
-					Instances: []types.Instance {
+					Instances: []types.Instance{
 						{
 							InstanceId: aws.String("i-0123456789abcdef0"),
 							LaunchTime: aws.Time(time.Date(2023, 1, 5, 12, 0, 0, 0, time.UTC)),
@@ -59,7 +59,7 @@ func TestEc2id(t *testing.T) {
 					},
 				},
 				{
-					Instances: []types.Instance {
+					Instances: []types.Instance{
 						{
 							InstanceId: aws.String("i-00000000000abcdef"),
 							LaunchTime: aws.Time(time.Date(2023, 1, 4, 12, 0, 0, 0, time.UTC)),
@@ -74,19 +74,19 @@ func TestEc2id(t *testing.T) {
 		DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
 			Filters: []types.Filter{
 				{
-					Name: aws.String("instance-state-name"),
+					Name:   aws.String("instance-state-name"),
 					Values: []string{"running"},
 				},
 				{
-					Name: aws.String("tag:Name"),
+					Name:   aws.String("tag:Name"),
 					Values: []string{"test"},
 				},
 			},
 		}).
 		Return(&ec2.DescribeInstancesOutput{
-			Reservations: []types.Reservation {
+			Reservations: []types.Reservation{
 				{
-					Instances: []types.Instance {
+					Instances: []types.Instance{
 						{
 							InstanceId: aws.String("i-00000000000abcdef"),
 							LaunchTime: aws.Time(time.Date(2023, 1, 4, 12, 0, 0, 0, time.UTC)),
@@ -98,36 +98,36 @@ func TestEc2id(t *testing.T) {
 		AnyTimes()
 
 	cases := []struct {
-		name string
-		client EC2DescribeInstancesAPI
+		name         string
+		client       EC2DescribeInstancesAPI
 		instanceName string
-		expect string
-		wantErr bool
-		expectErr string
+		expect       string
+		wantErr      bool
+		expectErr    string
 	}{
 		{
-			name: "return no instance-id",
-			client: mockClient,
+			name:         "return no instance-id",
+			client:       mockClient,
 			instanceName: "noexist",
-			expect: "",
-			wantErr: false,
-			expectErr: "",
+			expect:       "",
+			wantErr:      false,
+			expectErr:    "",
 		},
 		{
-			name: "return latest instance-id by no input",
-			client: mockClient,
+			name:         "return latest instance-id by no input",
+			client:       mockClient,
 			instanceName: "",
-			expect: "i-0123456789abcdef2",
-			wantErr: false,
-			expectErr: "",
+			expect:       "i-0123456789abcdef2",
+			wantErr:      false,
+			expectErr:    "",
 		},
 		{
-			name: "return instance-id",
-			client: mockClient,
+			name:         "return instance-id",
+			client:       mockClient,
 			instanceName: "test",
-			expect: "i-00000000000abcdef",
-			wantErr: false,
-			expectErr: "",
+			expect:       "i-00000000000abcdef",
+			wantErr:      false,
+			expectErr:    "",
 		},
 	}
 
@@ -135,7 +135,7 @@ func TestEc2id(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			id, err := Ec2id(tt.instanceName, tt.client)
 			if tt.wantErr {
-				if (!strings.Contains(err.Error(), tt.expectErr)) {
+				if !strings.Contains(err.Error(), tt.expectErr) {
 					t.Errorf("expect NoSuchKey error, got %T", err)
 				}
 				return

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 			return err
 		},
 		HideHelpCommand: true,
-		Version: getVersion(),
+		Version:         getVersion(),
 	}
 
 	err := app.Run(os.Args)


### PR DESCRIPTION
If no argument specified, it is treated as filter instance with `tag:Name = ""`.
Fix filter rule and return all instances if no argument specified.

solves: #8