### PR TITLE
Add homepage and description in homebrew

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,3 +42,5 @@ brews:
       owner: thaim
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: "https://github.com/thaim/ec2id"
+    description: "A CLI tool that retrieve the EC2 instance ID of specified instance's Name tag"


### PR DESCRIPTION
There are missing items on homebrew configurations.
Add homepage and description in homebrew.

https://github.com/thaim/homebrew-tap/blob/b31ed1bf669992e45e996b3563c1bdeb67fa6aaa/ec2id.rb#L6