### PR TITLE
Show version and revsion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-GIT_VERSION := $(shell git rev-list -1 HEAD)
+GIT_VERSION := $(shell git describe --abbrev=0 --tags)
+GIT_REVISION := $(shell git rev-list -1 HEAD)
 DATE := $(shell date +%Y-%m-%dT%H:%M%Sz)
 
 help: ## Show help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-12s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 build: *.go test ## Build binary
-	go build -ldflags "-s -w -X main.version=${GIT_VERSION} -X main.buildDate=${DATE}" -trimpath -o bin/ec2id
+	go build -ldflags "-s -w -X main.version=${GIT_VERSION} -X main.revision=${GIT_REVISION} -X main.buildDate=${DATE}" -trimpath -o bin/ec2id
 
 test: ## Run test
 	go test ./...

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ var (
 	all     bool
 	verbose bool
 	version = ""
+	revision = ""
 )
 
 func main() {
@@ -48,7 +49,7 @@ func main() {
 			return err
 		},
 		HideHelpCommand: true,
-		Version:         getVersion(),
+		Version:         fmt.Sprintf("%s (rev:%s)", getVersion(), getRevision()),
 	}
 
 	err := app.Run(os.Args)
@@ -70,6 +71,24 @@ func getVersion() string {
 	}
 
 	return i.Main.Version
+}
+
+func getRevision() string {
+	if revision != "" {
+		return revision
+	}
+	i, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unkown"
+	}
+
+	for _, s := range i.Settings {
+		if s.Key == "vcs.revision" {
+			return s.Value
+		}
+	}
+
+	return "unknown"
 }
 
 func printIds(out io.Writer, ids []string, all bool) {

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 			return err
 		},
 		HideHelpCommand: true,
-		Version:         fmt.Sprintf("%s (rev:%s)", getVersion(), getRevision()),
+		Version:         versionFormatter(getVersion(), getRevision()),
 	}
 
 	err := app.Run(os.Args)
@@ -61,13 +61,24 @@ func main() {
 	os.Exit(0)
 }
 
+func versionFormatter(version string, revision string) string {
+	if version == "" {
+		version = "devel"
+	}
+
+	if revision == "" {
+		return version
+	}
+	return fmt.Sprintf("%s (rev: %s)", version, revision)
+}
+
 func getVersion() string {
 	if version != "" {
 		return version
 	}
 	i, ok := debug.ReadBuildInfo()
 	if !ok {
-		return "unknown"
+		return ""
 	}
 
 	return i.Main.Version
@@ -79,7 +90,7 @@ func getRevision() string {
 	}
 	i, ok := debug.ReadBuildInfo()
 	if !ok {
-		return "unkown"
+		return ""
 	}
 
 	for _, s := range i.Settings {
@@ -88,7 +99,7 @@ func getRevision() string {
 		}
 	}
 
-	return "unknown"
+	return ""
 }
 
 func printIds(out io.Writer, ids []string, all bool) {

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,48 @@ import (
 	"testing"
 )
 
+func TestMainVersionFormatter(t * testing.T) {
+	cases := []struct {
+		name     string
+		version  string
+		revision string
+		expect   string
+	}{
+		{
+			name:     "specified version and revision",
+			version:  "v1.0.0",
+			revision: "0123456789abcdef",
+			expect:   "v1.0.0 (rev: 0123456789abcdef)",
+		},
+		{
+			name:     "specified version only",
+			version:  "v1.0.0",
+			revision: "",
+			expect:   "v1.0.0",
+		},
+		{
+			name:     "specified revision only",
+			version:  "",
+			revision: "0123456789abcdef",
+			expect:   "devel (rev: 0123456789abcdef)",
+		},
+		{
+			name:     "no version and revision specified",
+			version:  "",
+			revision: "",
+			expect:   "devel",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if actual := versionFormatter(tt.version, tt.revision); actual != tt.expect {
+				t.Errorf("expect %s, got id: %s", tt.expect, actual)
+			}
+		})
+	}
+}
+
 func TestMainPrintIds(t *testing.T) {
 	cases := []struct {
 		name    string


### PR DESCRIPTION
When ec2id --version flag is specified, print version and revision.

If version cannot retrieved, show "devel" as version.
If revision cannot retrieved, remote revision print.